### PR TITLE
fix: read chat log with UTF8 instead of Unicode

### DIFF
--- a/Services/LogWatcherService.cs
+++ b/Services/LogWatcherService.cs
@@ -77,7 +77,7 @@ namespace WIMP_IntelLog.Services
                     currentFile = mostRecentFile;
 
                     fs = new FileStream(currentFile.Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                    sr = new StreamReader(fs, Encoding.Unicode);
+                    sr = new StreamReader(fs, Encoding.UTF8);
                 }
 
                 while (sr != null)


### PR DESCRIPTION
Changed the text mode of read log files from Unicode to UTF8.

closes #28 